### PR TITLE
fix: Handle add policy without a cg config file

### DIFF
--- a/src/commands/policy/add.ts
+++ b/src/commands/policy/add.ts
@@ -1,21 +1,8 @@
 import { PluginType } from '@cloudgraph/sdk'
 import { isEmpty, uniqBy } from 'lodash'
+import { DEFAULT_CG_CONFIG } from '../../utils/constants'
 
 import OperationBaseCommand from '../operation'
-
-const defaultCGConfig = {
-  cloudGraph: {
-    plugins: {},
-    storageConfig: {
-      host: 'localhost',
-      port: '8997',
-      scheme: 'http',
-    },
-    versionLimit: 10,
-    queryEngine: 'playground',
-    port: '5555',
-  },
-}
 
 export default class AddPolicy extends OperationBaseCommand {
   static description = 'Add new policy packs'
@@ -42,7 +29,7 @@ export default class AddPolicy extends OperationBaseCommand {
         } = installedPolicy
 
         // Save policy to CG config file
-        const config = this.getCGConfig() || defaultCGConfig
+        const config = this.getCGConfig() || DEFAULT_CG_CONFIG
         let configuredPolicies =
           config.cloudGraph.plugins?.[PluginType.PolicyPack] || []
         if (isEmpty(configuredPolicies)) {

--- a/src/commands/policy/add.ts
+++ b/src/commands/policy/add.ts
@@ -3,6 +3,20 @@ import { isEmpty, uniqBy } from 'lodash'
 
 import OperationBaseCommand from '../operation'
 
+const defaultCGConfig = {
+  cloudGraph: {
+    plugins: {},
+    storageConfig: {
+      host: 'localhost',
+      port: '8997',
+      scheme: 'http',
+    },
+    versionLimit: 10,
+    queryEngine: 'playground',
+    port: '5555',
+  },
+}
+
 export default class AddPolicy extends OperationBaseCommand {
   static description = 'Add new policy packs'
 
@@ -28,37 +42,35 @@ export default class AddPolicy extends OperationBaseCommand {
         } = installedPolicy
 
         // Save policy to CG config file
-        const config = this.getCGConfig()
-        if (config) {
-          let configuredPolicies =
-            config.cloudGraph.plugins?.[PluginType.PolicyPack] || []
-          if (isEmpty(configuredPolicies)) {
-            // Set new Policy Pack Plugin array
-            configuredPolicies = [
-              {
-                name: key,
-                providers: [provider],
-              },
-            ]
-          } else {
-            // Add policy to Policy Pack Plugin array
-            configuredPolicies = [
-              ...configuredPolicies,
-              {
-                name: key,
-                providers: [provider],
-              },
-            ]
-          }
-          if (!config.cloudGraph.plugin) {
-            config.cloudGraph.plugins = {}
-          }
-          config.cloudGraph.plugins[PluginType.PolicyPack] = uniqBy(
-            configuredPolicies,
-            'name'
-          )
-          this.saveCloudGraphConfigFile(config)
+        const config = this.getCGConfig() || defaultCGConfig
+        let configuredPolicies =
+          config.cloudGraph.plugins?.[PluginType.PolicyPack] || []
+        if (isEmpty(configuredPolicies)) {
+          // Set new Policy Pack Plugin array
+          configuredPolicies = [
+            {
+              name: key,
+              providers: [provider],
+            },
+          ]
+        } else {
+          // Add policy to Policy Pack Plugin array
+          configuredPolicies = [
+            ...configuredPolicies,
+            {
+              name: key,
+              providers: [provider],
+            },
+          ]
         }
+        if (!config.cloudGraph.plugin) {
+          config.cloudGraph.plugins = {}
+        }
+        config.cloudGraph.plugins[PluginType.PolicyPack] = uniqBy(
+          configuredPolicies,
+          'name'
+        )
+        this.saveCloudGraphConfigFile(config)
       }
     } catch (error) {
       this.logger.debug(error)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,3 +25,13 @@ export const messages = {
     plural: 'providers',
   },
 }
+
+export const DEFAULT_CG_CONFIG = {
+  cloudGraph: {
+    plugins: {},
+    storageConfig: DEFAULT_CONFIG,
+    versionLimit: 10,
+    queryEngine: 'playground',
+    port: '5555',
+  },
+}


### PR DESCRIPTION
## Issue tracker links

[CG-893](https://autoclouddev.atlassian.net/browse/CG-893)

## Changes/solution

- Handle cases when the user tries to add a new policy, and there are not cg config file yet.
 
## Testing

1. install cg
2. delete any pre-existing config file
3. run `cg add policy aws-cis-1.2.0`
4. run `cg init aws`
5. run `cg scan`
6. the configured policies should be executed.

