### PR TITLE
Update Altair GraphQL website

### DIFF
--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -50,7 +50,7 @@ export const queryEngineConfigQuestions: ListQuestion[] = [
         short: 'GraphQL Playground',
       },
       {
-        name: 'Altair GraphQL Client (https://altair.sirmuel.design/)',
+        name: 'Altair GraphQL Client (https://altairgraphql.dev)',
         value: 'altair',
         short: 'Altair GraphQL Client',
       },


### PR DESCRIPTION
The canonical website for Altair GraphQL Client has changed to https://altairgraphql.dev. This updates it accordingly.

## Issue tracker links

_Add links to any relevant tasks/stories/bugs/pagerduty/etc_

*Example - dummy TODO project*

[TODO-123](https://autoclouddev.atlassian.net/browse/TODO-123)

## Changes/solution

_How does this change address the problem?_

## Testing

_Describe how the testing was done, plus evidence, if not covered by automated tests_

## Notes and considerations

_Add any additional notes and/or considerations_

## Dependencies

_Add dependencies on any other PRs, if applicable 
